### PR TITLE
MLflow 3.0 migration and other changes

### DIFF
--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_deployment/model_serving/notebooks/ModelServing.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_deployment/model_serving/notebooks/ModelServing.py.tmpl
@@ -39,7 +39,7 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install -qqqq databricks-agents
+# MAGIC %pip install -qqqq databricks-agents==1.1.0 mlflow==3.1.1
 
 # COMMAND ----------
 
@@ -64,11 +64,11 @@ dbutils.widgets.text(
     "agent_function_chatbot",
     label="Registered model name",
 )
-# Model version
+# Model alias
 dbutils.widgets.text(
-    "model_version",
-    "1",
-    label="Model Version",
+    "model_alias",
+    "agent_latest",
+    label="Model Alias",
 )
 # Scale to zero
 dbutils.widgets.dropdown("scale_to_zero", "True", ["True", "False"], "Scale to zero")
@@ -84,14 +84,14 @@ dbutils.library.restartPython()
 uc_catalog = dbutils.widgets.get("uc_catalog")
 schema = dbutils.widgets.get("schema")
 registered_model = dbutils.widgets.get("registered_model")
-model_version = dbutils.widgets.get("model_version")
+model_alias = dbutils.widgets.get("model_alias")
 scale_to_zero = bool(dbutils.widgets.get("scale_to_zero"))
 workload_size = dbutils.widgets.get("workload_size")
 
 assert uc_catalog != "", "uc_catalog notebook parameter must be specified"
 assert schema != "", "schema notebook parameter must be specified"
 assert registered_model != "", "registered_model notebook parameter must be specified"
-assert model_version != "", "model_version notebook parameter must be specified"
+assert model_alias != "", "model_alias notebook parameter must be specified"
 assert scale_to_zero != "", "scale_to_zero notebook parameter must be specified"
 assert workload_size != "", "workload_size notebook parameter must be specified"
 
@@ -103,7 +103,6 @@ notebook_path =  '/Workspace/' + os.path.dirname(dbutils.notebook.entry_point.ge
 %cd ../serving
 
 # COMMAND ----------
-
 # DBTITLE 1,Review Instructions
 instructions_to_reviewer = f"""### Instructions for Testing the our Chatbot assistant
 
@@ -123,24 +122,30 @@ Your inputs are invaluable for the development team. By providing detailed feedb
 Thank you for your time and effort in testing our assistant. Your contributions are essential to delivering a high-quality product to our end users."""
 
 # COMMAND ----------
+# DBTITLE 1,Create agent deployment
 
 from databricks import agents
+from mlflow import MlflowClient
 
-# Deploy to enable the Review APP and create an API endpoint
-# Note it deploys model on endpoint and enables inference table
+client = MlflowClient()
+
 model_name = f"{uc_catalog}.{schema}.{registered_model}"
+model_version = client.get_model_version_by_alias(model_name, model_alias).version
 
 if not agents.get_deployments(model_name):
     deployment_info = agents.deploy(model_name=model_name, model_version=int(model_version), scale_to_zero=scale_to_zero, workload_size=workload_size)
 else:
     deployment_info = agents.get_deployments(model_name)[0]
-    print(f"Deployment {model_name} already exists")
+    print(f"Deployment {model_name} already exists. Deleting and redeploying...")
+    agents.delete_deployment(model_name=model_name, model_version=deployment_info.version)
+    deployment_info = agents.deploy(model_name=model_name, model_version=int(model_version), scale_to_zero=scale_to_zero, workload_size=workload_size)
 
 
 # Add the user-facing instructions to the Review App
 agents.set_review_instructions(model_name, instructions_to_reviewer)
 
 # COMMAND ----------
+# DBTITLE 1, Wait for model serving endpoint to be ready
 
 # DBTITLE 1,Test Endpoint
 from serving import wait_for_model_serving_endpoint_to_be_ready
@@ -159,6 +164,7 @@ wait_for_model_serving_endpoint_to_be_ready(deployment_info.endpoint_name)
 # print(f"Share this URL with your stakeholders: {deployment_info.review_app_url}")
 
 # COMMAND ----------
+# DBTITLE 1,Test endpoint
 
 from mlflow.deployments import get_deploy_client
 

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent/agent_requirements.txt.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent/agent_requirements.txt.tmpl
@@ -1,5 +1,0 @@
-unitycatalog-langchain[databricks]==0.1.1
-databricks-vectorsearch==0.50
-databricks-langchain==0.4.0
-langgraph==0.3.5
-mlflow==2.20.3

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent/notebooks/Agent.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent/notebooks/Agent.py.tmpl
@@ -40,7 +40,7 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install -qqqq -r ../agent_requirements.txt
+# MAGIC %pip install -qqqq -r ../../agent_requirements.txt
 
 # COMMAND ----------
 
@@ -101,6 +101,9 @@ dbutils.widgets.text(
     "agent_latest",
     label="Model Alias",
 )
+
+# COMMAND ----------
+dbutils.library.restartPython()
 
 # COMMAND ----------
 
@@ -229,64 +232,98 @@ mlflow.langchain.autolog()
 # COMMAND ----------
 
 # DBTITLE 1,Use the tools in Langgraph
-from typing import Literal
-from langgraph.graph import END, START, MessagesState, StateGraph
-from langgraph.prebuilt import ToolNode
-from databricks_langchain import ChatDatabricks
+from typing import Any, Generator, Optional, Sequence, Union, Literal
+import mlflow
+from databricks_langchain import (
+    ChatDatabricks,
+    UCFunctionToolkit,
+    VectorSearchRetrieverTool,
+)
+from langchain_core.language_models import LanguageModelLike
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_core.tools import BaseTool
+from langgraph.graph import START, END, StateGraph
+from langgraph.prebuilt.tool_node import ToolNode
+from mlflow.langchain.chat_agent_langgraph import ChatAgentState, ChatAgentToolNode
+from mlflow.pyfunc import ChatAgent
+from mlflow.types.agent import (
+    ChatAgentChunk,
+    ChatAgentMessage,
+    ChatAgentResponse,
+    ChatContext,
+)
 
 tools = uc_tools + [retrieve_function]
 
-tool_node = ToolNode(tools)
-
 # Example for Databricks foundation model endpoints
-model = ChatDatabricks(
-    endpoint=f"{agent_model_endpoint}",  # Foundation Model endpoint name
-).bind_tools(tools)
+model = ChatDatabricks(endpoint=f"{agent_model_endpoint}")
+system_prompt = "You are a Databricks expert. "
 
-# Define the function that determines whether to continue or not
-def should_continue(state: MessagesState) -> Literal["tools", END]:
-    messages = state["messages"]
-    last_message = messages[-1]
-    # If the LLM makes a tool call, then we route to the "tools" node
-    if last_message.tool_calls:
-        return "tools"
-    # Otherwise, we stop (reply to the user)
-    return END
+def create_tool_calling_agent(
+    model: LanguageModelLike, 
+    tools: Union[ToolNode, Sequence[BaseTool]], 
+    system_prompt: Optional[str]=None
+): 
+    model = model.bind_tools(tools)
 
+    # Define the function that determines whether to continue or not
+    def should_continue(state: ChatAgentState) -> Literal["tools", END]:
+        messages = state["messages"]
+        last_message = messages[-1]
+        # If the LLM makes a tool call, then we route to the "tools" node
+        if last_message.get("tool_calls"):
+            return "tools"
+        # Otherwise, we stop (reply to the user)
+        return END
 
-# Define the function that calls the model
-def call_model(state: MessagesState):
-    messages = state["messages"]
-    response = model.invoke(messages)
-    # We return a list, because this will get added to the existing list
-    return {"messages": [response]}
+    preprocessor = RunnableLambda(
+        lambda state: [{"role": "system", "content": system_prompt}]
+        + state["messages"]
+    )
+    model_runnable = preprocessor | model
 
+    # Define the function that calls the model
+    def call_model(state: ChatAgentState, config: RunnableConfig):
+        # Loop to make sure the tool call is executed correctly
+        failing = True
+        retry = 10
+        while failing and retry>=0: 
+            try: 
+                response = model_runnable.invoke(state, config)
+                failing = False
+            except: 
+                retry -= 1
+        # We return a list, because this will get added to the existing list
+        return {"messages": [response]}
 
-# Define a new graph
-workflow = StateGraph(MessagesState)
+    # Define a new graph
+    workflow = StateGraph(ChatAgentState)
 
-# Define the two nodes we will cycle between
-workflow.add_node("agent", call_model)
-workflow.add_node("tools", tool_node)
+    # Define the two nodes we will cycle between
+    tool_node = ChatAgentToolNode(tools)
+    workflow.add_node("agent", RunnableLambda(call_model))
+    workflow.add_node("tools", tool_node)
 
-# Set the entrypoint as `agent`
-# This means that this node is the first one called
-workflow.add_edge(START, "agent")
+    # Set the entrypoint as `agent`
+    # This means that this node is the first one called
+    workflow.add_edge(START, "agent")
 
-# We now add a conditional edge
-workflow.add_conditional_edges(
-    # First, we define the start node. We use `agent`.
-    # This means these are the edges taken after the `agent` node is called.
-    "agent",
-    # Next, we pass in the function that will determine which node is called next.
-    should_continue,
-)
+    # We now add a conditional edge
+    workflow.add_conditional_edges(
+        # First, we define the start node. We use `agent`.
+        # This means these are the edges taken after the `agent` node is called.
+        "agent",
+        # Next, we pass in the function that will determine which node is called next.
+        should_continue,
+    )
 
-# We now add a normal edge from `tools` to `agent`.
-# This means that after `tools` is called, `agent` node is called next.
-workflow.add_edge("tools", "agent")
+    # We now add a normal edge from `tools` to `agent`.
+    # This means that after `tools` is called, `agent` node is called next.
+    workflow.add_edge("tools", "agent")
 
-app = workflow.compile()
+    return workflow.compile()
+
+app = create_tool_calling_agent(model, tools, system_prompt)
 
 # COMMAND ----------
 
@@ -300,8 +337,7 @@ final_state = app.invoke(
         ]
     },
 )
-response = final_state["messages"][-1].content
-response
+response = final_state["messages"][-1].get('content')
 
 # COMMAND ----------
 
@@ -315,126 +351,190 @@ final_state = app.invoke(
         ]
     },
 )
-final_state["messages"][-1].content
+final_state["messages"][-1].get('content')
 
 # COMMAND ----------
 
 final_state = app.invoke(
     {"messages": [{"role": "user", "content": "What is MLflow?"}]},
 )
-final_state["messages"][-1].content
+final_state["messages"][-1].get('content')
 
 # COMMAND ----------
 
 # DBTITLE 1,Log the model using MLflow
-# MAGIC %%writefile app.py
-# MAGIC from mlflow.models import set_model
-# MAGIC from unitycatalog.ai.core.base import set_uc_function_client
-# MAGIC from unitycatalog.ai.core.databricks import DatabricksFunctionClient
-# MAGIC from langgraph.prebuilt import ToolNode
-# MAGIC from langgraph.checkpoint.memory import MemorySaver
-# MAGIC from langgraph.graph import END, START, StateGraph, MessagesState
-# MAGIC from typing import Annotated, Literal, TypedDict
-# MAGIC from unitycatalog.ai.langchain.toolkit import UCFunctionToolkit
-# MAGIC from databricks_langchain import ChatDatabricks, VectorSearchRetrieverTool
-# MAGIC from langchain_core.tools import tool
-# MAGIC import os
+# MAGIC %%writefile ../notebooks/app.py
+# MAGIC from typing import Any, Generator, Optional, Sequence, Union, Literal
+# MAGIC import mlflow
+# MAGIC from databricks_langchain import (
+# MAGIC     ChatDatabricks,
+# MAGIC     UCFunctionToolkit,
+# MAGIC     VectorSearchRetrieverTool,
+# MAGIC )
+# MAGIC from langchain_core.language_models import LanguageModelLike
+# MAGIC from langchain_core.runnables import RunnableConfig, RunnableLambda
+# MAGIC from langchain_core.tools import BaseTool
+# MAGIC from langgraph.graph import START, END, StateGraph
+# MAGIC from langgraph.prebuilt.tool_node import ToolNode
+# MAGIC from mlflow.langchain.chat_agent_langgraph import ChatAgentState, ChatAgentToolNode
+# MAGIC from mlflow.pyfunc import ChatAgent
+# MAGIC from mlflow.types.agent import (
+# MAGIC     ChatAgentChunk,
+# MAGIC     ChatAgentMessage,
+# MAGIC     ChatAgentResponse,
+# MAGIC     ChatContext,
+# MAGIC )
 # MAGIC
 # MAGIC uc_catalog = "{{.input_catalog_name}}"
 # MAGIC schema = "{{.input_schema_name}}"
-# MAGIC vector_search_endpoint = "databricks_documentation_vs_index"
 # MAGIC
 # MAGIC python_execution_function_name = f"{uc_catalog}.{schema}.execute_python_code"
 # MAGIC ask_ai_function_name = f"{uc_catalog}.{schema}.ask_ai"
 # MAGIC summarization_function_name = f"{uc_catalog}.{schema}.summarize"
 # MAGIC translate_function_name = f"{uc_catalog}.{schema}.translate"
 # MAGIC
-# MAGIC # Retriever
 # MAGIC @tool
 # MAGIC def retrieve_function(query: str) -> str:
 # MAGIC     """Retrieve from Databricks Vector Search using the query."""
 # MAGIC
 # MAGIC     index = f"{uc_catalog}.{schema}.databricks_documentation_vs_index"
 # MAGIC
-# MAGIC     # Define the Vector Search Retriever Tool
 # MAGIC     vs_tool = VectorSearchRetrieverTool(
-# MAGIC         index_name=index,  # Replace with your index name
+# MAGIC         index_name=index,
 # MAGIC         tool_name="vector_search_retriever",
 # MAGIC         tool_description="Retrieves information from Databricks Vector Search.",
-# MAGIC         embedding_model_name="databricks-bge-large-en",  # Embedding model
-# MAGIC         num_results=1,  # Number of results to return
-# MAGIC         columns=["url", "content"],  # Columns to include in search results
-# MAGIC         query_type="ANN"  # Query type (ANN or HYBRID)
+# MAGIC         embedding_model_name="databricks-bge-large-en", 
+# MAGIC         num_results=1, 
+# MAGIC         columns=["url", "content"],
+# MAGIC         query_type="ANN" 
 # MAGIC     )
 # MAGIC
 # MAGIC     response = vs_tool.invoke(query)
 # MAGIC     return f"{response[0].metadata['url']}  \n{response[0].page_content}"
-# MAGIC
-# MAGIC # Add tools here
+# MAGIC   
 # MAGIC toolkit = UCFunctionToolkit(
-# MAGIC     function_names=[
-# MAGIC         python_execution_function_name,
-# MAGIC         # ask_ai_function_name, # commenting out to showcase retriever
-# MAGIC         summarization_function_name,
-# MAGIC         translate_function_name,
+# MAGIC   function_names=[
+# MAGIC     python_execution_function_name,
+# MAGIC     # ask_ai_function_name, # commenting out to showcase retriever
+# MAGIC     summarization_function_name,
+# MAGIC     translate_function_name,
 # MAGIC     ]
 # MAGIC )
 # MAGIC uc_tools = toolkit.tools
-# MAGIC
 # MAGIC tools = uc_tools + [retrieve_function]
 # MAGIC
-# MAGIC tool_node = ToolNode(tools)
+# MAGIC # Example for Databricks foundation model endpoints
+# MAGIC model = ChatDatabricks(endpoint="databricks-meta-llama-3-3-70b-instruct")
+# MAGIC system_prompt = "You are a Databricks expert. "
 # MAGIC
-# MAGIC model = ChatDatabricks(
-# MAGIC     endpoint="databricks-meta-llama-3-3-70b-instruct",  # Foundation Model endpoint name
-# MAGIC ).bind_tools(tools)
+# MAGIC def create_tool_calling_agent(
+# MAGIC     model: LanguageModelLike, 
+# MAGIC     tools: Union[ToolNode, Sequence[BaseTool]], 
+# MAGIC     system_prompt: Optional[str]=None
+# MAGIC ): 
+# MAGIC     model = model.bind_tools(tools)
 # MAGIC
-# MAGIC def should_continue(state: MessagesState) -> Literal["tools", END]:
-# MAGIC     messages = state['messages']
-# MAGIC     last_message = messages[-1]
-# MAGIC     if last_message.tool_calls:
-# MAGIC         return "tools"
-# MAGIC     return END
+# MAGIC     def should_continue(state: ChatAgentState) -> Literal["tools", END]:
+# MAGIC         messages = state["messages"]
+# MAGIC         last_message = messages[-1]
+# MAGIC         if last_message.get("tool_calls"):
+# MAGIC             return "tools"
+# MAGIC         return END
 # MAGIC
-# MAGIC def call_model(state: MessagesState):
-# MAGIC     messages = state['messages']
-# MAGIC     response = model.invoke(messages)
-# MAGIC     return {"messages": [response]}
+# MAGIC     preprocessor = RunnableLambda(lambda state: [{"role": "system", "content": system_prompt}] + state["messages"])
+# MAGIC     model_runnable = preprocessor | model
 # MAGIC
-# MAGIC workflow = StateGraph(MessagesState)
-# MAGIC workflow.add_node("agent", call_model)
-# MAGIC workflow.add_node("tools", tool_node)
-# MAGIC workflow.add_edge(START, "agent")
-# MAGIC workflow.add_conditional_edges("agent", should_continue)
-# MAGIC workflow.add_edge("tools", 'agent')
+# MAGIC     def call_model(state: ChatAgentState, config: RunnableConfig):
+# MAGIC         failing = True
+# MAGIC         retry = 10
+# MAGIC         while failing and retry>=0: 
+# MAGIC             try: 
+# MAGIC                 response = model_runnable.invoke(state, config)
+# MAGIC                 failing = False
+# MAGIC             except: 
+# MAGIC                 retry -= 1
+# MAGIC         return {"messages": [response]}
 # MAGIC
-# MAGIC app = workflow.compile()
-# MAGIC set_model(app)
+# MAGIC     workflow = StateGraph(ChatAgentState)
+# MAGIC
+# MAGIC     tool_node = ChatAgentToolNode(tools)
+# MAGIC     workflow.add_node("agent", RunnableLambda(call_model))
+# MAGIC     workflow.add_node("tools", tool_node)
+# MAGIC     workflow.add_edge(START, "agent")
+# MAGIC     workflow.add_conditional_edges("agent", should_continue)
+# MAGIC     workflow.add_edge("tools", "agent")
+# MAGIC     return workflow.compile()
+# MAGIC
+# MAGIC class LangGraphChatAgent(ChatAgent):
+# MAGIC     def __init__(self, agent):
+# MAGIC         self.agent = agent
+# MAGIC
+# MAGIC     def predict(
+# MAGIC         self,
+# MAGIC         messages: list[ChatAgentMessage],
+# MAGIC         context: Optional[ChatContext] = None,
+# MAGIC         custom_inputs: Optional[dict[str, Any]] = None,
+# MAGIC     ) -> ChatAgentResponse:
+# MAGIC         request = {"messages": self._convert_messages_to_dict(messages)}
+# MAGIC
+# MAGIC         messages = []
+# MAGIC         for event in self.agent.stream(request, stream_mode="updates"):
+# MAGIC             for node_data in event.values():
+# MAGIC                 messages.extend(
+# MAGIC                     ChatAgentMessage(**msg) for msg in node_data.get("messages", [])
+# MAGIC                 )
+# MAGIC         return ChatAgentResponse(messages=messages)
+# MAGIC
+# MAGIC     def predict_stream(
+# MAGIC         self,
+# MAGIC         messages: list[ChatAgentMessage],
+# MAGIC         context: Optional[ChatContext] = None,
+# MAGIC         custom_inputs: Optional[dict[str, Any]] = None,
+# MAGIC     ) -> Generator[ChatAgentChunk, None, None]:
+# MAGIC         request = {"messages": self._convert_messages_to_dict(messages)}
+# MAGIC         for event in self.agent.stream(request, stream_mode="updates"):
+# MAGIC             for node_data in event.values():
+# MAGIC                 yield from (
+# MAGIC                     ChatAgentChunk(**{"delta": msg}) for msg in node_data["messages"]
+# MAGIC                 )
+# MAGIC
+# MAGIC
+# MAGIC # Create the agent object, and specify it as the agent object to use when
+# MAGIC # loading the agent back for inference via mlflow.models.set_model()
+# MAGIC mlflow.langchain.autolog()
+# MAGIC agent = create_tool_calling_agent(llm, tools, system_prompt)
+# MAGIC AGENT = LangGraphChatAgent(agent)
+# MAGIC mlflow.models.set_model(AGENT)
 
 # COMMAND ----------
 
 import mlflow
-from mlflow.models import infer_signature
-
-# temp workaround as the current output format is not supported by model signature
-input_example = {"messages": [{"role": "user", "content": "What is MLflow?"}]}
-signature = infer_signature(input_example, "MLflow is an open-source platform that streamlines the machine learning lifecycle by providing tools for experiment tracking, model packaging, versioning, and deployment.")
+from mlflow.models.resources import DatabricksFunction, DatabricksServingEndpoint, DatabricksVectorSearchIndex
+from pkg_resources import get_distribution
 
 mlflow.set_experiment(experiment)
 
+resources = [
+    DatabricksServingEndpoint(endpoint_name=agent_model_endpoint), 
+    DatabricksFunction(f"{uc_catalog}.{schema}.execute_python_code"), 
+    DatabricksFunction(f"{uc_catalog}.{schema}.ask_ai"), 
+    DatabricksFunction(f"{uc_catalog}.{schema}.summarize"), 
+    DatabricksFunction(f"{uc_catalog}.{schema}.translate"), 
+    DatabricksVectorSearchIndex(index_name=f"{uc_catalog}.{schema}.{vector_search_index}")
+]
+
 with mlflow.start_run():
-    model_info = mlflow.langchain.log_model(
-        # Pass the path to the saved model file
-        "app.py",
-        "model",
-        input_example={"messages": [{"role": "user", "content": "What is MLflow?"}]},
-        signature=signature,
+    model_info = mlflow.pyfunc.log_model(
+        python_model="../notebooks/app.py", # Pass the path to the saved model file
+        name="model",
+        resources=resources, 
         pip_requirements=[
-            "unitycatalog-langchain[databricks]==0.1.1",
-            "databricks-vectorsearch==0.50",
-            "databricks-langchain==0.4.0",
-            "langgraph==0.3.5",
-            "mlflow==2.20.3",
+            f"databricks-connect=={get_distribution('databricks-connect').version}",
+            f"unitycatalog-langchain[databricks]=={get_distribution('unitycatalog-langchain[databricks]').version}",
+            f"databricks-vectorsearch=={get_distribution('databricks-vectorsearch').version}",
+            f"databricks-langchain=={get_distribution('databricks-langchain').version}",
+            f"langgraph=={get_distribution('langgraph').version}",
+            f"mlflow=={get_distribution('mlflow').version}",
         ],
         registered_model_name=f"{uc_catalog}.{schema}.{registered_model}"  # Replace with your own model name
     )
@@ -447,8 +547,8 @@ from mlflow import MlflowClient
 # Initialize MLflow client
 client = MlflowClient()
 
-# Set an alias for version 1 of the registered model to retrieve it for model serving
-client.set_registered_model_alias(f"{uc_catalog}.{schema}.{registered_model}", model_alias, 1)
+# Set an alias for new version of the registered model to retrieve it for model serving
+client.set_registered_model_alias(f"{uc_catalog}.{schema}.{registered_model}", model_alias, model_info.registered_model_version)
 
 
 # COMMAND ----------

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_evaluation/evaluation/evaluation.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_evaluation/evaluation/evaluation.py.tmpl
@@ -1,9 +1,10 @@
-import pandas as pd
-
 def get_reference_documentation(catalog, schema, table, spark):
-    (spark.createDataFrame(pd.read_parquet('https://notebooks.databricks.com/demos/dbdemos-dataset/llm/databricks-documentation/databricks_doc_eval_set.parquet'))
-    .write.mode('overwrite').saveAsTable(f"{catalog}.{schema}.{table}"))
+    import pandas as pd 
+    from pyspark.sql.functions import col, struct
+    ref_docs = (spark.createDataFrame(pd.read_parquet('https://notebooks.databricks.com/demos/dbdemos-dataset/llm/databricks-documentation/databricks_doc_eval_set.parquet'))
+                .withColumnRenamed('request', 'inputs')
+                .withColumnRenamed('expected_response', 'expectations')
+                .withColumn('inputs', struct(col('inputs').alias('question')))
+                .withColumn('expectations', struct(col('expectations').alias('expected_response'))))
 
-    eval_df = spark.read.table(f"{catalog}.{schema}.{table}")
-
-    return eval_df
+    return ref_docs

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_evaluation/notebooks/AgentEvaluation.py.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_evaluation/notebooks/AgentEvaluation.py.tmpl
@@ -73,11 +73,11 @@ dbutils.widgets.text(
     "agent_function_chatbot",
     label="Registered model name",
 )
-# Model version
+# Model alias
 dbutils.widgets.text(
-    "model_version",
-    "1",
-    label="Model Version",
+    "model_alias",
+    "agent_latest",
+    label="Model Alias",
 )
 
 # COMMAND ----------
@@ -87,14 +87,19 @@ schema = dbutils.widgets.get("schema")
 eval_table = dbutils.widgets.get("eval_table")
 experiment = dbutils.widgets.get("experiment")
 registered_model = dbutils.widgets.get("registered_model")
-model_version = dbutils.widgets.get("model_version")
+model_alias = dbutils.widgets.get("model_alias")
 
 assert uc_catalog != "", "uc_catalog notebook parameter must be specified"
 assert schema != "", "schema notebook parameter must be specified"
 assert eval_table != "", "eval_table notebook parameter must be specified"
 assert experiment != "", "experiment notebook parameter must be specified"
 assert registered_model != "", "registered_model notebook parameter must be specified"
-assert model_version != "", "model_version notebook parameter must be specified"
+assert model_alias != "", "model_alias notebook parameter must be specified"
+
+
+# COMMAND ----------
+
+dbutils.library.restartPython()
 
 # COMMAND ----------
 
@@ -106,42 +111,64 @@ notebook_path =  '/Workspace/' + os.path.dirname(dbutils.notebook.entry_point.ge
 
 # COMMAND ----------
 
-# DBTITLE 1,Get Evaluation Dataset
+# DBTITLE 1,Create Evaluation Dataset
+import mlflow.genai.datasets
+
+try: 
+    eval_dataset = mlflow.genai.datasets.create_dataset(
+        uc_table_name=f"{uc_catalog}.{schema}.{eval_table}",
+    )
+except: 
+    # Eval table already exists 
+    eval_dataset = mlflow.genai.datasets.get_dataset(
+        uc_table_name=f"{uc_catalog}.{schema}.{eval_table}",
+    )
+
+print(f"Evaluation dataset: {uc_catalog}.{schema}.{eval_table}")
+
+# COMMAND ----------
+
+# DBTITLE 1,Get Reference Documentation
 from evaluation import get_reference_documentation
 
-eval_dataset = get_reference_documentation(uc_catalog, schema, eval_table, spark)
+reference_docs = get_reference_documentation(uc_catalog, schema, eval_table, spark)
 
-display(eval_dataset)
+display(reference_docs)
+
+# COMMAND ----------
+
+# DBTITLE 1,Merge Reference Docs to Eval Dataset
+eval_dataset.merge_records(reference_docs.limit(100))
+
+# Preview the dataset
+df = eval_dataset.to_df()
+print(f"\nDataset preview:")
+print(f"Total records: {len(df)}")
+print("\nSample record:")
+sample = df.iloc[0]
+print(f"Inputs: {sample['inputs']}")
 
 # COMMAND ----------
 
 # DBTITLE 1,Run Evaluation
-import databricks.agents
+import mlflow 
+from mlflow.genai.scorers import scorer
+from mlflow.genai.scorers import RetrievalRelevance, RetrievalGroundedness
 import re
-import mlflow
 
 # Workaround for serverless compatibility
 mlflow.tracking._model_registry.utils._get_registry_uri_from_spark_session = lambda: "databricks-uc"
 
-# Retrieve model info for run
-client = mlflow.MlflowClient()
+model = mlflow.pyfunc.load_model(f"models:/{uc_catalog}.{schema}.{registered_model}@{model_alias}")
+def evaluate_model(question):
+    return model.predict({"messages": [{"role": "user", "content": question}]})
 
-model_info = client.get_model_version(f"{uc_catalog}.{schema}.{registered_model}", model_version)
-
-# Set experiment
-pattern = r"^(.*?)/agent_evaluation"
-match = re.match(pattern, notebook_path)
-if match:
-    path = match.group(1)
-else:
-    path = None
-
-mlflow.set_experiment(f"{path}/{experiment}")
+mlflow.set_experiment(experiment)
 
 with mlflow.start_run():
     # Evaluate the logged model
-    eval_results = mlflow.evaluate(
-        data=eval_dataset.limit(10),
-        model=f'runs:/{model_info.run_id}/model',
-        model_type="databricks-agent",
+    eval_results = mlflow.genai.evaluate(
+        data=eval_dataset,
+        predict_fn=evaluate_model,
+        scorers=[RetrievalRelevance(), RetrievalGroundedness()],
     )

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_requirements.txt.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/agent_development/agent_requirements.txt.tmpl
@@ -1,6 +1,6 @@
-unitycatalog-langchain[databricks]==0.1.1
-databricks-vectorsearch==0.50
-databricks-langchain==0.4.0
-langgraph==0.3.5
-mlflow==2.22.0
-databricks-agents==0.22.0
+unitycatalog-langchain[databricks]==0.2.0
+databricks-vectorsearch==0.56
+databricks-langchain==0.5.1
+langgraph==0.5.0
+mlflow==3.1.1
+databricks-agents==1.1.0

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks.yml.tmpl
@@ -51,9 +51,9 @@ variables:
   eval_table:
     description: "Table in Unity Catalog to store evaluation data."
     default: "databricks_documentation_eval"
-  model_version:
-    description: "Version of model to evaluate."
-    default: 1
+  model_alias:
+    description: "Model alias to use for trained model"
+    default: agent_latest
   scale_to_zero:
     description: "Scale model endpoint to zero when not in use."
     default: True

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/agent-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/agent-resource.yml.tmpl
@@ -21,6 +21,7 @@ resources:
               registered_model: ${var.registered_model}
               agent_model_endpoint: ${var.agent_model_endpoint}
               max_words: ${var.max_words}
+              model_alias: ${var.model_alias}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
 
@@ -34,7 +35,7 @@ resources:
               schema: ${var.schema}
               registered_model: ${var.registered_model}
               eval_table: ${var.eval_table}
-              model_version: ${var.model_version}
+              model_alias: ${var.model_alias}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
 
@@ -47,7 +48,7 @@ resources:
               uc_catalog: ${var.uc_catalog}
               schema: ${var.schema}
               registered_model: ${var.registered_model}
-              model_version: ${var.model_version}
+              model_alias: ${var.model_alias}
               scale_to_zero: ${var.scale_to_zero}
               workload_size: ${var.workload_size}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/agents-artifacts-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/resources/agents-artifacts-resource.yml.tmpl
@@ -20,6 +20,13 @@ resources:
         schema_name: ${var.schema}
         comment: Registered model in Unity Catalog for the "mlops-example-project" ML Project for ${bundle.target} deployment target.
         <<: *grants
+      
+      feedback_model: 
+        name: feedback
+        catalog_name: ${var.uc_catalog}
+        schema_name: ${var.schema}
+        comment: Registered model for the agent's feedback for ${bundle.target} deployment target.
+        <<: *grants
 
   experiments:
     experiment:


### PR DESCRIPTION
MLflow 3.0 migration
- Agent Evaluation
    - Updated schema of the reference docs to reflect requirements of eval sets ("inputs", "expectations" instead of "request" and "expected response")
    - Created a dataset via `mlflow.genai` + merged the reference docs to it. Theoretically, we can merge prod traces there as well
    - Added evaluation function as a wrapper for `predict_fn` in `mlflow.genai.evaluate()`
    - Imported scorers-- I only used two here, but we can add custom ones in the future

Updated agent code itself
- use ChatAgent as a wrapper on top of the existing langgraph code
    - primary benefit: no longer any 'signature' warnings; automatically inferred signature for all ChatAgent flavors
- Replaced the MessagesState (outdated) with the ChatAgentState (supported by Databricks)
- added a loop to retry in case the LLM did not format the tool call correctly
    - Llama 3.3 models do not seem great at tool calling-- added a for loop, so it will retry if it is a format issue. The evaluation looks better after this change. 

Other changes
- Consolidated multiple agent_requirements.txt file to prevent confusion
- Use model alias as the primary identifier instead of model version-- helps when rerunning workflows
- Delete agent deployment + redeploy if one already exists-- otherwise the old agent deployment persists without update
- Added feedback model to DAB resource definition